### PR TITLE
Fix: Correct university name spelling from Yeungin to Yeungjin

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
-# 🌍 Welcome to **GSC-Lab** @ Yeungin University! 🌟  
+# 🌍 Welcome to **GSC-Lab** @ Yeungjin University! 🌟  
 
 ### About Global System Convergence (GSC)
-The **Global System Convergence (GSC)** department at Yeungin University is a cutting-edge academic program established in 2024. We are committed to producing highly skilled **Machine Learning (ML) engineers** equipped with practical expertise and global competence.
+The **Global System Convergence (GSC)** department at Yeungjin University is a cutting-edge academic program established in 2024. We are committed to producing highly skilled **Machine Learning (ML) engineers** equipped with practical expertise and global competence.
 
 ### Our Vision: Building the Next Generation of ML Engineers
 At GSC, we are dedicated to equipping students with advanced skills in AI and ML, empowering them to become highly capable ML engineers. Many of our graduates join top Japanese IT companies, driving technological innovation and contributing to global advancements in the field.


### PR DESCRIPTION
## Summary
- Corrected the spelling of the university name from "Yeungin" to "Yeungjin" in two places

## Changes
- Line 1: Updated university name in the header
- Line 4: Updated university name in the GSC description

Co-Authored-By: @claude